### PR TITLE
Ignore old rolls

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "summary": "A Symbiote to watch the D&D Beyond Game Log from a Campaign and report the rolls into TaleSpire.",
   "entryPoint": "/index.html",
   "descriptionFilePath": "/README.md",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "about": {
     "website": "https://github.com/PanoramicPanda/ddb_observeGameLog",
     "authors": [

--- a/observeGameLog.js
+++ b/observeGameLog.js
@@ -14,7 +14,7 @@ function observeGameLog() {
                         const roll = extractDataFromLi(addedLi);
                         const rollTarget = roll.rollTarget.toLowerCase();
 
-                        if (!(rollTarget === 'to: self') && !(rollTarget === 'to: dm')) {
+                        if (!(rollTarget === 'to: self') && !(rollTarget === 'to: dm') && !(roll.diceRoll === '')) {
                             let diceRoll = roll.diceRoll;
                             let color = "<color=\"white\">";
                             if (diceRoll.includes('d20')) {


### PR DESCRIPTION
Added empty dice rolls to filter. Old rolls that get queried from scrolling up to view roll history no longer log as new rolls in TaleSpire

Udpated version count

fixes #12 